### PR TITLE
Replace file_redirect env variable with labels for file redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./logs:/logs
+    labels:
+      - kibbo.config.log_mode=optout
 ```
 
 Now you are logging all of your compose containers to `logs`
@@ -30,13 +32,14 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./logs:/logs
-    environment:
-      - APPEND=TRUE
+    labels:
+      - kibbo.config.log_mode=optout
+      - kibbo.config.log_file_update_mode=append
 ```
 
-## TIMESTAMPS
+## Timestamps
 
-Timestamps can also be included in the logs. Just add `- INCLUDE_TIMESTAMPS=TRUE` the following:
+Timestamps can be included in the logs. Just add `- INCLUDE_TIMESTAMPS=TRUE` to the following:
 
 ```yaml
 version: "3"
@@ -47,6 +50,5 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./logs:/logs
     environment:
-     - APPEND=TRUE
      - INCLUDE_TIMESTAMPS=TRUE
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Now you are logging all of your compose containers to `logs`
 
 ## Persisted Logs
 
-If you are interested in having your logs persisted across services updates (ie. You logs to stay if you rebuild and deploy the same service.) then all you need to do is add the following to the yaml above:
+If you are interested in having your logs persisted across services updates (ie. Your logs stay if you rebuild and deploy the same service.) then all you need to do is add the following to the yaml above:
 
 ```yaml
 version: "3"
@@ -39,7 +39,7 @@ services:
 
 ## Timestamps
 
-Timestamps can be included in the logs. Just add `- INCLUDE_TIMESTAMPS=TRUE` to the following:
+Timestamps can be included in the logs. Just add `- kibbo.config.log_file_include_timestamps=true` to the following:
 
 ```yaml
 version: "3"
@@ -49,6 +49,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./logs:/logs
-    environment:
-     - INCLUDE_TIMESTAMPS=TRUE
+    labels:
+      - kibbo.config.log_mode=optout
+      - kibbo.config.log_file_include_timestamps=true
 ```

--- a/kibbo/entrypoint.sh
+++ b/kibbo/entrypoint.sh
@@ -28,15 +28,28 @@ check_if_logger_running() {
     fi
 }
 
+set_file_redirect_operator() {
+    local append
+    append=$(eval "docker container inspect $hostname | jq -r \".[0].Config.Labels.\\\"kibbo.config.log_file_update_mode\\\"\"")
+
+    case $append in
+        "append")
+            echo "Log file redirect mode: append"
+            file_redirect_operator=">>"
+            ;;
+        "replace")
+            echo "Log file redirect mode: replace"
+            file_redirect_operator=">"
+            ;;
+        *)
+            echo "Invalid redirect mode: $append. Defaulting to replace"
+            file_redirect_operator=">"
+    esac
+}
+
 run_logs_for_container() {
     local container_id=$1
     local container_name=$2
-
-    if [ "$APPEND" = "TRUE" ]; then
-        local append=">>"
-    else
-        local append=">"
-    fi
 
     if [ "$INCLUDE_TIMESTAMPS" = "TRUE" ]; then
         local include_timestamps="--timestamps"
@@ -48,12 +61,25 @@ run_logs_for_container() {
 
     etcdctl put "$container_id" "$container_name"
 
-    command="docker logs -f $include_timestamps $container_id $append /logs/$container_name.log 2>&1"
+    command="docker logs -f $include_timestamps $container_id $file_redirect_operator /logs/$container_name.log 2>&1"
     eval "$command"
 
     echo "Removing $container_name from etcd"
     etcdctl del $container_id
+}
 
+set_opt_in_out() {
+    opt_setting=$(eval "docker container inspect $hostname | jq -r \".[0].Config.Labels.\\\"kibbo.config.log_mode\\\"\"")
+    case $opt_setting in
+        "optout")
+            echo "Services: Opt out"
+            ;;
+        "replace")
+            echo "Services: Opt in"
+            ;;
+        *)
+            echo "Invalid opt mode: $opt_setting. Defaulting to Opt out"
+    esac
 }
 
 
@@ -70,7 +96,7 @@ check_and_update_loggers() {
                 if [ $logger_running -eq "0" ]; then
                     echo "$container_name logger not started. Starting..."
                     run_logs_for_container "$container_id" "$container_name" &
-                    
+
                 else
                     echo "$container_name logger running already. Skipping..."
                 fi
@@ -79,16 +105,29 @@ check_and_update_loggers() {
     return
 }
 
-setup_etcd
+set_hostname() {
+    hostname=$(cat /etc/hostname)
+    etcdctl put hostname $hostname
+    echo "Hostname: $hostname"
+}
 
-hostname=$(cat /etc/hostname)
-etcdctl put hostname $hostname
-echo "hostname is $hostname"
-network=$(docker ps --format json | jq -r 'select(.ID=="'$hostname'") | .Networks')
-etcdctl put network $network
-echo "Network is $network"
+set_network() {
+    network=$(docker ps --format json | jq -r 'select(.ID=="'$hostname'") | .Networks')
+    etcdctl put network $network
+    echo "Network: $network"
+}
 
-while true; do
-    check_and_update_loggers;
-    sleep 10; # TODO: wait for all background processes to exit instead
-done
+main() {
+    setup_etcd
+    set_hostname
+    set_network
+    set_opt_in_out
+    set_file_redirect_operator
+
+    while true; do
+        check_and_update_loggers;
+        sleep 10; # TODO: wait for all background processes to exit instead
+    done
+}
+
+main

--- a/kibbo/entrypoint.sh
+++ b/kibbo/entrypoint.sh
@@ -47,15 +47,29 @@ set_file_redirect_operator() {
     esac
 }
 
+set_timestamps_arg() {
+    local include_timestamps
+    include_timestamps=$(eval "docker container inspect $hostname | jq -r \".[0].Config.Labels.\\\"kibbo.config.log_file_include_timestamps\\\"\"")
+
+    case $include_timestamps in
+        "true")
+            echo "Log file include timestamps: true"
+            log_file_include_timestamps="--timestamps"
+            ;;
+        "false")
+            echo "Log file include timestamps: false"
+            log_file_include_timestamps=""
+            ;;
+        *)
+            echo "Invalid include timestamps option: $append. Defaulting to true"
+            log_file_include_timestamps="--timestamps"
+    esac
+}
+
+
 run_logs_for_container() {
     local container_id=$1
     local container_name=$2
-
-    if [ "$INCLUDE_TIMESTAMPS" = "TRUE" ]; then
-        local include_timestamps="--timestamps"
-    else
-        local include_timestamps=""
-    fi
 
     echo "Inserting $container_name into etcd"
 
@@ -123,6 +137,7 @@ main() {
     set_network
     set_opt_in_out
     set_file_redirect_operator
+    set_timestamps_arg
 
     while true; do
         check_and_update_loggers;


### PR DESCRIPTION
In reference to #17 . This take the first step into using labels for services and introduces the opt-in opt-out feature.

The `file_redirect` operator being used here is being replaced with a label.
This PR also paves the way for other services to opt-out of being logged.