### PR TITLE
Run loggers on startup

### DIFF
--- a/kibbo/entrypoint.sh
+++ b/kibbo/entrypoint.sh
@@ -114,7 +114,7 @@ set_opt_in_out() {
         "optout")
             echo "Services: Opt out"
             ;;
-        "replace")
+        "optin")
             echo "Services: Opt in"
             ;;
         *)


### PR DESCRIPTION
Loggers start for relevant containers given chosen policy upon startup. There is no need to restart containers on first start to get the loggers running.